### PR TITLE
cleaning duplicates

### DIFF
--- a/tap_pipedrive/stream.py
+++ b/tap_pipedrive/stream.py
@@ -7,6 +7,9 @@ logger = singer.get_logger()
 
 
 class PipedriveStream(object):
+    def __init__(self):
+        self.ids = []
+
     tap = None
     endpoint = ''
     key_properties = []


### PR DESCRIPTION
# Description of change
Cleaning duplicate values because the API returns a random number of records come both at the end of a page and at the beginning of the next one, creating duplicates. 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
